### PR TITLE
Removing panel proxy from qhub-onprem

### DIFF
--- a/files/environments/jupyterlab.yaml
+++ b/files/environments/jupyterlab.yaml
@@ -4,17 +4,18 @@ channels:
 dependencies:
   - pip
   - nb_conda_kernels
+  # required to launch jupterlab from jupyterhub
+  - jupyterhub
   # jupyterhub menu https://github.com/jupyterlab/jupyterlab/issues/9428
   - jupyterlab>=3.0.4
   - ipywidgets>=7.6.0
   - ipyparallel
+  # dask
   - dask-gateway
   - dask-labextension>=5.0.0
-  # panel
-  - jupyter-panel-proxy
-  # required to launch jupterlab from jupyterhub
-  - jupyterhub
+  # dashboard
   - cdsdashboards-singleuser
+  - panel
   - pip:
       # batchspawner latest slurm fixes
       - https://github.com/jupyterhub/batchspawner/archive/129951ad11e3049567b94adb8c9725dc22225a1a.tar.gz


### PR DESCRIPTION
Now that we are using cds dashbaord this is no longer required.